### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "java10"
+run = "javac Day1.java"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Advent-Of-Code-2019
 Solutions to 2019 Advent Of Code Problems
+
+[![Run on Repl.it](https://repl.it/badge/github/KimofyTheDev/Advent-Of-Code-2019)](https://repl.it/github/KimofyTheDev/Advent-Of-Code-2019)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@SyedAhmad1/Advent-Of-Code-2020).